### PR TITLE
fix: generate_init error

### DIFF
--- a/bolt_expressions/api.py
+++ b/bolt_expressions/api.py
@@ -87,16 +87,10 @@ class Expression:
         self.called_init = True
 
     def generate_init(self):
-        scoreboard = self.ctx.inject(Scoreboard)
-        path = self.ctx.generate.path(self.opts.init_path)
-        self.ctx.data[path] = Function(self.init_commands)
-        if not self.called_init:
-            if tag := self.ctx.data.function_tags.get("minecraft:load", None):
-                tag["values"].insert(0, path)
-            else:
-                self.ctx.data.function_tags["minecraft:load"] = FunctionTag(
-                    {"values": [path]}
-                )
+        self.ctx.generate(
+            self.opts.init_path,
+            Function(self.init_commands, prepend_tags=["minecraft:load"]),
+        )
 
 
 @dataclass


### PR DESCRIPTION
`tag["values"].insert(0, path)` should have been `tag.data["values"].insert(0, path)` since the content of the file is exposed through the `.data` property. But `beet`'s generator api lets you simplify the whole thing quite a bit.